### PR TITLE
Fix compilation errors and updated gyronimo to latest version

### DIFF
--- a/examples/calculate_loss_fraction_vmec.py
+++ b/examples/calculate_loss_fraction_vmec.py
@@ -44,7 +44,9 @@ g_orbits = ParticleEnsembleOrbit_Simple(
 )
 total_time = time.time() - start_time
 print(f"  Running with {g_orbits.nparticles} particles took {total_time}s")
-print(f"  Loss fraction = {100*g_orbits.loss_fraction_array[-1]}% for a time of {tfinal}s")
+print(
+    f"  Loss fraction = {100*g_orbits.loss_fraction_array[-1]}% for a time of {tfinal}s"
+)
 
 # Plot resulting loss fraction
 g_orbits.plot_loss_fraction()

--- a/examples/optimize_loss_fraction_qi.py
+++ b/examples/optimize_loss_fraction_qi.py
@@ -45,7 +45,6 @@ class optimize_loss_fraction:
         parallel=False,
         constant_b20=constant_b20,
     ) -> None:
-
         self.field = field
         self.particles = particles
         self.nsamples = nsamples

--- a/examples/optimize_loss_fraction_qs.py
+++ b/examples/optimize_loss_fraction_qs.py
@@ -46,7 +46,6 @@ class optimize_loss_fraction:
         parallel=False,
         constant_b20=constant_b20,
     ) -> None:
-
         self.field = field
         self.particles = particles
         self.nsamples = nsamples

--- a/src/neat/fields.py
+++ b/src/neat/fields.py
@@ -268,7 +268,6 @@ if simple_loaded:
             ns_s: int = 3,
             ns_tp: int = 3,
         ) -> None:
-
             self.near_axis = False
             self.wout_filename = wout_filename
             net_file = netcdf.netcdf_file(self.wout_filename, "r", mmap=False)

--- a/src/neat/objectives.py
+++ b/src/neat/objectives.py
@@ -43,7 +43,6 @@ class LossFractionResidual(Optimizable):
         nthreads=2,
         r_max=0.12,
     ) -> None:
-
         self.field = field
         self.particles = particles
         self.nsamples = nsamples
@@ -91,7 +90,6 @@ class EffectiveVelocityResidual(Optimizable):
         r_max=0.12,
         constant_b20=True,
     ) -> None:
-
         self.field = field
         self.particles = particles
         self.nsamples = nsamples
@@ -163,7 +161,6 @@ class OptimizeLossFractionSkeleton:
         tfinal=0.0001,
         nthreads=2,
     ) -> None:
-
         # log(level=logging.DEBUG)
 
         self.field = field

--- a/src/neat/tracing.py
+++ b/src/neat/tracing.py
@@ -53,7 +53,6 @@ class ChargedParticle:
         theta_initial=np.pi,
         phi_initial=0,
     ) -> None:
-
         self.charge = charge
         self.mass = mass
         self.energy = energy
@@ -104,7 +103,6 @@ class ChargedParticleEnsemble:
         ntheta=10,
         nphi=10,
     ) -> None:
-
         self.charge = charge
         self.mass = mass
         self.energy = energy
@@ -152,7 +150,6 @@ class ParticleOrbit:  # pylint: disable=R0902
         tfinal=0.0001,
         constant_b20=False,
     ) -> None:
-
         self.particle = particle
         self.field = field
         self.nsamples = nsamples
@@ -364,7 +361,6 @@ class ParticleEnsembleOrbit:  # pylint: disable=R0902
         nthreads=2,
         constant_b20=True,
     ) -> None:
-
         self.particles = particles
         self.field = field
         self.nsamples = nsamples
@@ -539,7 +535,6 @@ class ParticleEnsembleOrbit_Simple:  # pylint: disable=R0902
         npoiper2=128,
         nper=1000,
     ) -> None:
-
         self.particles = particles
         # Change later to a definition of a variable called nparticles
         self.nparticles = nparticles

--- a/src/neatpp/stellna.hh
+++ b/src/neatpp/stellna.hh
@@ -1,5 +1,17 @@
 #include <omp.h>
 #include <numbers>
+using namespace std;
+#include <array>
+// Define multiplication by scalar and vector sum
+std::array<double,4> operator*(const double& a, const array<double,4>& v) {
+    array<double, 4> result = {a*v[0], a*v[1], a*v[2], a*v[3]};
+    return result;
+}
+std::array<double,4> operator+(
+    const array<double,4>& u, const array<double,4>& v) {
+    array<double, 4> result = {u[0]+v[0],u[1]+v[1],u[2]+v[2],u[3]+v[3]};
+    return result;
+}
 #include <boost/numeric/odeint/stepper/runge_kutta4.hpp>
 #include <boost/numeric/odeint/integrate/integrate_const.hpp>
 #include <gyronimo/core/codata.hh>
@@ -15,7 +27,6 @@
 #include "metric_stellna.hh"
 #include "equilibrium_stellna.hh"
 using namespace gyronimo;
-using namespace std;
 
 // Normalization to SI units
 double Lref = 1.0;
@@ -54,17 +65,6 @@ vector<double> neat_linspace(T start_in, T end_in, int num_in)
   linspaced.push_back(end); // I want to ensure that start and end
                             // are exactly the same as the input
   return linspaced;
-}
-
-// Define multiplication by scalar and vector sum
-array<double,4> operator*(const double& a, const array<double,4>& v) {
-    array<double, 4> result = {a*v[0], a*v[1], a*v[2], a*v[3]};
-    return result;
-}
-array<double,4> operator+(
-    const array<double,4>& u, const array<double,4>& v) {
-    array<double, 4> result = {u[0]+v[0],u[1]+v[1],u[2]+v[2],u[3]+v[3]};
-    return result;
 }
 
 // Particle ensemble class. The "Gyrons"!

--- a/tests/verify_metric.py
+++ b/tests/verify_metric.py
@@ -934,7 +934,6 @@ def verifyMetric(count):
 
 
 if __name__ == "__main__":
-
     # fig = plt.figure()
     # fig.patch.set_facecolor('white')
     # ax = fig.gca(projection='3d')


### PR DESCRIPTION
When compiling, NEAT would give an error regarding the overloading of the + and * operators of the array class. stellna.hh has been fixed accordingly.
The bicubic_gsl needed an extra import <algorithm>.
Gyronimo was updated to latest version.